### PR TITLE
Hybrid PS + SD Glyphs

### DIFF
--- a/theme/ps-hybrid/ps-hybrid.css
+++ b/theme/ps-hybrid/ps-hybrid.css
@@ -1,0 +1,7 @@
+:root {
+	/* Standard Inputs */
+	--zbpg-face-up:  url("/themes_custom/Button%20Prompts%20Galore/ds2/imgs/shared_button_t.svg");
+	--zbpg-face-dn:  url("/themes_custom/Button%20Prompts%20Galore/ds2/imgs/shared_button_x.svg");
+	--zbpg-face-lf:  url("/themes_custom/Button%20Prompts%20Galore/ds2/imgs/shared_button_s.svg");
+	--zbpg-face-rt:  url("/themes_custom/Button%20Prompts%20Galore/ds2/imgs/shared_button_o.svg");
+}

--- a/theme/theme.json
+++ b/theme/theme.json
@@ -28,6 +28,9 @@
 				"DualSense": {
 					"ds5/ds5.css": ["SP", "QuickAccess"]
 				},
+				"PS Hybrid": {
+					"ps-hybrid/ps-hybrid.css": ["SP", "QuickAccess"]
+				},
 				"XInput": {
 					"xbox/xbox.css": ["SP", "QuickAccess"]
 				}


### PR DESCRIPTION
Use the PlayStation glyphs included with the DualShock 2 theme, but retain every other Steam Deck default glyph. Useful for those who have the custom PlayStation buttons from SakuraRetroModding.