### PR TITLE
add option to override playstation buttons

### DIFF
--- a/theme/patches/override_ps.css
+++ b/theme/patches/override_ps.css
@@ -1,0 +1,15 @@
+img[src="/steaminputglyphs/ps_button_triangle.svg"]{  /* face button up (Δ) */
+    content: var(--zbpg-face-up, url("/steaminputglyphs/ps_button_triangle.svg"));
+}
+
+img[src="/steaminputglyphs/ps_button_x.svg"]{  /* face button down (Χ) */
+    content: var(--zbpg-face-dn, url("/steaminputglyphs/ps_button_x.svg"));
+}
+
+img[src="/steaminputglyphs/ps_button_square.svg"]{  /* face button left (Π) */
+    content: var(--zbpg-face-lf, url("/steaminputglyphs/ps_button_square.svg"));
+}
+
+img[src="/steaminputglyphs/ps_button_circle.svg"]{  /* face button right (Ο) */
+    content: var(--zbpg-face-rt, url("/steaminputglyphs/ps_button_circle.svg"));
+}

--- a/theme/theme.json
+++ b/theme/theme.json
@@ -1,37 +1,74 @@
 {
 	"name": "Button Prompts Galore",
-	"version": "v1.2",
 	"author": "ZeusOfTheCrows, InsaneCallum",
 	"target": "Tweak",
+	"version": "v1.3",
 	"description": "change controller button prompts. includes snes, switch, dualshock 2 & 3, DualSense, & xbox [coloured]",
-	"manifest_version": 3,
+	"manifest_version": 5,
 	"inject": {
-		"global.css": ["SP", "QuickAccess"]
+		"global.css": [
+			"SP",
+			"QuickAccess"
+		]
 	},
+	"dependencies": {},
 	"patches": {
 		"controller Type": {
-			"default": "Super NES",
 			"type": "dropdown",
-			"values":{
+			"default": "Super NES",
+			"values": {
 				"Super NES": {
-					"snes/snes.css": ["SP", "QuickAccess"]
+					"snes/snes.css": [
+						"SP",
+						"QuickAccess"
+					]
 				},
 				"Switch": {
-					"nsx/nsx.css": ["SP", "QuickAccess"]
+					"nsx/nsx.css": [
+						"SP",
+						"QuickAccess"
+					]
 				},
 				"DualShock 2": {
-					"ds2/ds2.css": ["SP", "QuickAccess"]
+					"ds2/ds2.css": [
+						"SP",
+						"QuickAccess"
+					]
 				},
 				"DualShock 3": {
-					"ds3/ds3.css": ["SP", "QuickAccess"]
+					"ds3/ds3.css": [
+						"SP",
+						"QuickAccess"
+					]
 				},
 				"DualSense": {
-					"ds5/ds5.css": ["SP", "QuickAccess"]
+					"ds5/ds5.css": [
+						"SP",
+						"QuickAccess"
+					]
 				},
 				"XInput": {
-					"xbox/xbox.css": ["SP", "QuickAccess"]
+					"xbox/xbox.css": [
+						"SP",
+						"QuickAccess"
+					]
 				}
-			}
+			},
+			"components": []
+		},
+		"override playstation": {
+			"type": "checkbox",
+			"default": "No",
+			"values": {
+				"Yes": {
+					"patches/override_ps.css": [
+						"SP",
+						"QuickAccess"
+					]
+				},
+				"No": {}
+			},
+			"components": []
 		}
 	}
 }


### PR DESCRIPTION
If you connect a playstation controller, the playstation glyphes are shown. If you like other glyphs more, or have a DualSense with modded face buttons (like me), this allows you to show the configured face buttons instead.

Maybe an option to also override the other PS buttons would be handy for someone else, but in my case, this made the most sense.